### PR TITLE
Add test for pharseMarkdown headings

### DIFF
--- a/tests/heading-article.json
+++ b/tests/heading-article.json
@@ -1,0 +1,11 @@
+{
+  "firstPublished": 42,
+  "title": "Heading Test Title",
+  "type": "heading-test",
+  "body": [
+    { "h1": "First Level" },
+    { "h2": "Second Level" },
+    { "h3": "Third Level" },
+    { "p": "Heading test paragraph" }
+  ]
+}

--- a/tests/heading-article.txt
+++ b/tests/heading-article.txt
@@ -1,0 +1,8 @@
+# Heading Test Title
+- type: heading-test
+- firstPublished: 42
+---
+# First Level
+## Second Level
+### Third Level
+Heading test paragraph

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,8 +1,9 @@
 import { pharseMarkdown } from "../src/functions";
 import chai from 'chai';
 import * as fs from 'fs';
-import validArticleInJson from "./valid-article.json"
-import invalidArticleInJson from "./invalid-article.json"
+import validArticleInJson from "./valid-article.json";
+import invalidArticleInJson from "./invalid-article.json";
+import headingArticleInJson from "./heading-article.json";
 
 describe('functions/index.pharseMarkdown()', () => {
   it('successfully pharsed', () => {
@@ -14,6 +15,11 @@ describe('functions/index.pharseMarkdown()', () => {
     const invalidArtilce = fs.readFileSync('./tests/invalid-article.txt', 'utf8');
     chai.expect(pharseMarkdown(validArtilce)).to.not.deep.equal(invalidArticleInJson);
     chai.expect(pharseMarkdown(invalidArtilce)).to.not.deep.equal(validArticleInJson);
+  });
+
+  it('pharsed heading levels', () => {
+    const headingArticle = fs.readFileSync('./tests/heading-article.txt', 'utf8');
+    chai.expect(pharseMarkdown(headingArticle)).to.deep.equal(headingArticleInJson);
   });
 });
 


### PR DESCRIPTION
## Summary
- add test for parsing heading levels
- add sample markdown and expected JSON for heading test

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1c8d7b388332b5a7df569b3e452e